### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Changelog (Pillow)
 
 - Fix OOB Read in Jpeg2KDecode. CVE 2021-25287, CVE 2021-25288
   [emilieyyu]
+
+- Use snprintf instead of sprintf. CVE-2021-34552
+  [wooken]
   
 6.2.2.1 (2021-10-08)
 ------------------

--- a/docs/releasenotes/6.2.2.2.rst
+++ b/docs/releasenotes/6.2.2.2.rst
@@ -8,3 +8,5 @@ This release addresses several critical CVEs.
 
 CVE 2021-25287, CVE 2021-25288 has out-of-bounds read in J2kDecode, in 
 j2ku_graya_la.
+
+CVE-2021-34552 -- buffer overflow in Convert.c

--- a/src/libImaging/Convert.c
+++ b/src/libImaging/Convert.c
@@ -1618,17 +1618,15 @@ convert(Imaging imOut, Imaging imIn, const char *mode,
             break;
         }
 
-    if (!convert)
+    if (!convert) {
 #ifdef notdef
         return (Imaging) ImagingError_ValueError("conversion not supported");
 #else
-    {
-      static char buf[256];
-      /* FIXME: may overflow if mode is too large */
-      sprintf(buf, "conversion from %s to %s not supported", imIn->mode, mode);
-      return (Imaging) ImagingError_ValueError(buf);
-    }
+        static char buf[100];
+        snprintf(buf, 100, "conversion from %.10s to %.10s not supported", imIn->mode, mode);
+        return (Imaging)ImagingError_ValueError(buf);
 #endif
+    }
 
     imOut = ImagingNew2Dirty(mode, imOut, imIn);
     if (!imOut)
@@ -1681,10 +1679,14 @@ ImagingConvertTransparent(Imaging imIn, const char *mode,
     }
 #else
     {
-      static char buf[256];
-      /* FIXME: may overflow if mode is too large */
-      sprintf(buf, "conversion from %s to %s not supported in convert_transparent", imIn->mode, mode);
-      return (Imaging) ImagingError_ValueError(buf);
+        static char buf[100];
+        snprintf(
+            buf,
+            100,
+            "conversion from %.10s to %.10s not supported in convert_transparent",
+            imIn->mode,
+            mode);
+        return (Imaging)ImagingError_ValueError(buf);
     }
 #endif
 


### PR DESCRIPTION
This is fix for CVE-2021-34552

(cherry picked from commit 518ee3722a99d7f7d890db82a20bd81c1c0327fb)