### PR TITLE
BE-154-CVE-2021-23437

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ since Pillow 4.3.0.
 - Fix CVE-2021-25291
   [rickprice]
 
+- Fix for CVE-2021-23437
+  [rickprice]
+
 6.2.2.3 (2023-02-23)
 ------------------
 

--- a/Tests/test_imagecolor.py
+++ b/Tests/test_imagecolor.py
@@ -29,9 +29,12 @@ class TestImageColor(PillowTestCase):
 
         # case insensitivity
         self.assertEqual(ImageColor.getrgb("#DEF"), ImageColor.getrgb("#def"))
-        self.assertEqual(ImageColor.getrgb("#CDEF"), ImageColor.getrgb("#cdef"))
-        self.assertEqual(ImageColor.getrgb("#DEFDEF"), ImageColor.getrgb("#defdef"))
-        self.assertEqual(ImageColor.getrgb("#CDEFCDEF"), ImageColor.getrgb("#cdefcdef"))
+        self.assertEqual(ImageColor.getrgb("#CDEF"),
+                         ImageColor.getrgb("#cdef"))
+        self.assertEqual(ImageColor.getrgb("#DEFDEF"),
+                         ImageColor.getrgb("#defdef"))
+        self.assertEqual(ImageColor.getrgb("#CDEFCDEF"),
+                         ImageColor.getrgb("#cdefcdef"))
 
         # not a number
         self.assertRaises(ValueError, ImageColor.getrgb, "#fo0")
@@ -76,48 +79,65 @@ class TestImageColor(PillowTestCase):
 
         self.assertEqual((255, 0, 0), ImageColor.getrgb("hsv(0,100%,100%)"))
         self.assertEqual((255, 0, 0), ImageColor.getrgb("hsv(360,100%,100%)"))
-        self.assertEqual((0, 255, 255), ImageColor.getrgb("hsv(180,100%,100%)"))
+        self.assertEqual(
+            (0, 255, 255), ImageColor.getrgb("hsv(180,100%,100%)"))
 
         # alternate format
         self.assertEqual(
-            ImageColor.getrgb("hsb(0,100%,50%)"), ImageColor.getrgb("hsv(0,100%,50%)")
+            ImageColor.getrgb("hsb(0,100%,50%)"), ImageColor.getrgb(
+                "hsv(0,100%,50%)")
         )
 
         # floats
-        self.assertEqual((254, 3, 3), ImageColor.getrgb("hsl(0.1,99.2%,50.3%)"))
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("hsl(360.,100.0%,50%)"))
+        self.assertEqual((254, 3, 3), ImageColor.getrgb(
+            "hsl(0.1,99.2%,50.3%)"))
+        self.assertEqual((255, 0, 0), ImageColor.getrgb(
+            "hsl(360.,100.0%,50%)"))
 
-        self.assertEqual((253, 2, 2), ImageColor.getrgb("hsv(0.1,99.2%,99.3%)"))
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("hsv(360.,100.0%,100%)"))
+        self.assertEqual((253, 2, 2), ImageColor.getrgb(
+            "hsv(0.1,99.2%,99.3%)"))
+        self.assertEqual((255, 0, 0), ImageColor.getrgb(
+            "hsv(360.,100.0%,100%)"))
 
         # case insensitivity
         self.assertEqual(
-            ImageColor.getrgb("RGB(255,0,0)"), ImageColor.getrgb("rgb(255,0,0)")
+            ImageColor.getrgb("RGB(255,0,0)"), ImageColor.getrgb(
+                "rgb(255,0,0)")
         )
         self.assertEqual(
-            ImageColor.getrgb("RGB(100%,0%,0%)"), ImageColor.getrgb("rgb(100%,0%,0%)")
+            ImageColor.getrgb("RGB(100%,0%,0%)"), ImageColor.getrgb(
+                "rgb(100%,0%,0%)")
         )
         self.assertEqual(
-            ImageColor.getrgb("RGBA(255,0,0,0)"), ImageColor.getrgb("rgba(255,0,0,0)")
+            ImageColor.getrgb("RGBA(255,0,0,0)"), ImageColor.getrgb(
+                "rgba(255,0,0,0)")
         )
         self.assertEqual(
-            ImageColor.getrgb("HSL(0,100%,50%)"), ImageColor.getrgb("hsl(0,100%,50%)")
+            ImageColor.getrgb("HSL(0,100%,50%)"), ImageColor.getrgb(
+                "hsl(0,100%,50%)")
         )
         self.assertEqual(
-            ImageColor.getrgb("HSV(0,100%,50%)"), ImageColor.getrgb("hsv(0,100%,50%)")
+            ImageColor.getrgb("HSV(0,100%,50%)"), ImageColor.getrgb(
+                "hsv(0,100%,50%)")
         )
         self.assertEqual(
-            ImageColor.getrgb("HSB(0,100%,50%)"), ImageColor.getrgb("hsb(0,100%,50%)")
+            ImageColor.getrgb("HSB(0,100%,50%)"), ImageColor.getrgb(
+                "hsb(0,100%,50%)")
         )
 
         # space agnosticism
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("rgb(  255  ,  0  ,  0  )"))
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("rgb(  100%  ,  0%  ,  0%  )"))
+        self.assertEqual((255, 0, 0), ImageColor.getrgb(
+            "rgb(  255  ,  0  ,  0  )"))
+        self.assertEqual((255, 0, 0), ImageColor.getrgb(
+            "rgb(  100%  ,  0%  ,  0%  )"))
         self.assertEqual(
-            (255, 0, 0, 0), ImageColor.getrgb("rgba(  255  ,  0  ,  0  ,  0  )")
+            (255, 0, 0, 0), ImageColor.getrgb(
+                "rgba(  255  ,  0  ,  0  ,  0  )")
         )
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("hsl(  0  ,  100%  ,  50%  )"))
-        self.assertEqual((255, 0, 0), ImageColor.getrgb("hsv(  0  ,  100%  ,  100%  )"))
+        self.assertEqual((255, 0, 0), ImageColor.getrgb(
+            "hsl(  0  ,  100%  ,  50%  )"))
+        self.assertEqual((255, 0, 0), ImageColor.getrgb(
+            "hsv(  0  ,  100%  ,  100%  )"))
 
         # wrong number of components
         self.assertRaises(ValueError, ImageColor.getrgb, "rgb(255,0)")
@@ -147,7 +167,8 @@ class TestImageColor(PillowTestCase):
     def test_rounding_errors(self):
 
         for color in ImageColor.colormap:
-            expected = Image.new("RGB", (1, 1), color).convert("L").getpixel((0, 0))
+            expected = Image.new("RGB", (1, 1), color).convert(
+                "L").getpixel((0, 0))
             actual = ImageColor.getcolor(color, "L")
             self.assertEqual(expected, actual)
 
@@ -157,22 +178,26 @@ class TestImageColor(PillowTestCase):
         Image.new("RGB", (1, 1), "white")
 
         self.assertEqual((0, 0, 0, 255), ImageColor.getcolor("black", "RGBA"))
-        self.assertEqual((255, 255, 255, 255), ImageColor.getcolor("white", "RGBA"))
+        self.assertEqual((255, 255, 255, 255),
+                         ImageColor.getcolor("white", "RGBA"))
         self.assertEqual(
-            (0, 255, 115, 33), ImageColor.getcolor("rgba(0, 255, 115, 33)", "RGBA")
+            (0, 255, 115, 33), ImageColor.getcolor(
+                "rgba(0, 255, 115, 33)", "RGBA")
         )
         Image.new("RGBA", (1, 1), "white")
 
         self.assertEqual(0, ImageColor.getcolor("black", "L"))
         self.assertEqual(255, ImageColor.getcolor("white", "L"))
-        self.assertEqual(162, ImageColor.getcolor("rgba(0, 255, 115, 33)", "L"))
+        self.assertEqual(162, ImageColor.getcolor(
+            "rgba(0, 255, 115, 33)", "L"))
         Image.new("L", (1, 1), "white")
 
         self.assertEqual(0, ImageColor.getcolor("black", "1"))
         self.assertEqual(255, ImageColor.getcolor("white", "1"))
         # The following test is wrong, but is current behavior
         # The correct result should be 255 due to the mode 1
-        self.assertEqual(162, ImageColor.getcolor("rgba(0, 255, 115, 33)", "1"))
+        self.assertEqual(162, ImageColor.getcolor(
+            "rgba(0, 255, 115, 33)", "1"))
         # Correct behavior
         # self.assertEqual(
         #     255, ImageColor.getcolor("rgba(0, 255, 115, 33)", "1"))
@@ -180,5 +205,13 @@ class TestImageColor(PillowTestCase):
 
         self.assertEqual((0, 255), ImageColor.getcolor("black", "LA"))
         self.assertEqual((255, 255), ImageColor.getcolor("white", "LA"))
-        self.assertEqual((162, 33), ImageColor.getcolor("rgba(0, 255, 115, 33)", "LA"))
+        self.assertEqual((162, 33), ImageColor.getcolor(
+            "rgba(0, 255, 115, 33)", "LA"))
         Image.new("LA", (1, 1), "white")
+
+    def test_color_too_long(self):
+        # Arrange
+        color_too_long = "hsl(" + "1" * 100 + ")"
+
+        # Act / Assert
+        self.assertRaises(ValueError, ImageColor.getrgb, color_too_long)

--- a/docs/releasenotes/6.2.2.4.rst
+++ b/docs/releasenotes/6.2.2.4.rst
@@ -17,5 +17,6 @@ since Pillow 4.3.0.
 
 :cve: `CVE-2021-27923` : Pillow before 8.1.1 allows attackers to cause a denial of service (memory consumption) because the reported size of a contained image is not properly checked for a BLP container, and thus an attempted memory allocation can be very large.
 
-
 :cve: `CVE-2021-25290` : Fix negative size read in TiffDecode.c
+
+:cve: `CVE-2021-23437` : Raise ValueError if color specifier is too long

--- a/src/PIL/ImageColor.py
+++ b/src/PIL/ImageColor.py
@@ -32,6 +32,8 @@ def getrgb(color):
     :param color: A color string
     :return: ``(red, green, blue[, alpha])``
     """
+    if len(color) > 100:
+        raise ValueError("color specifier is too long")
     color = color.lower()
 
     rgb = colormap.get(color, None)


### PR DESCRIPTION
Fixes BE-154 CVE-2021-23437 Raise ValueError if color specifier is too long