### PR TITLE
BE-2369 Pillow 6.2.2.5

### DIFF
--- a/src/libImaging/FliDecode.c
+++ b/src/libImaging/FliDecode.c
@@ -149,31 +149,32 @@ int ImagingFliDecode(Imaging im, ImagingCodecState state, UINT8 *buf,
       data += 4;
       for (; y < ymax && y < state->ysize; y++) {
         UINT8 *out = (UINT8 *)im->image[y];
-        ERR_IF_DATA_OOB(1)
-        int p, packets = *data++;
-        for (p = x = 0; p < packets; p++, x += i) {
-          ERR_IF_DATA_OOB(2)
-          x += data[0]; /* skip pixels */
-          if (data[1] & 0x80) {
-            i = 256 - data[1]; /* run */
-            if (x + i > state->xsize) {
-              break;
+        ERR_IF_DATA_OOB(1) {
+          int p, packets = *data++;
+          for (p = x = 0; p < packets; p++, x += i) {
+            ERR_IF_DATA_OOB(2)
+            x += data[0]; /* skip pixels */
+            if (data[1] & 0x80) {
+              i = 256 - data[1]; /* run */
+              if (x + i > state->xsize) {
+                break;
+              }
+              ERR_IF_DATA_OOB(3)
+              memset(out + x, data[2], i);
+              data += 3;
+            } else {
+              i = data[1]; /* chunk */
+              if (x + i > state->xsize) {
+                break;
+              }
+              ERR_IF_DATA_OOB(2 + i)
+              memcpy(out + x, data + 2, i);
+              data += i + 2;
             }
-            ERR_IF_DATA_OOB(3)
-            memset(out + x, data[2], i);
-            data += 3;
-          } else {
-            i = data[1]; /* chunk */
-            if (x + i > state->xsize) {
-              break;
-            }
-            ERR_IF_DATA_OOB(2 + i)
-            memcpy(out + x, data + 2, i);
-            data += i + 2;
           }
-        }
-        if (p < packets) {
-          break; /* didn't process all packets */
+          if (p < packets) {
+            break; /* didn't process all packets */
+          }
         }
       }
       if (y < ymax) {


### PR DESCRIPTION
Fix compiler error on Windows

Move protected variable definition into a sub-block so that the compiler
will accept it.

The safety test needs to be before the variable definition to protect
it, but the Windows compiler doesn't like code between variable
definitions.
