### PR TITLE
CVE-2023-44271: Added ImageFont.MAX_STRING_LENGTH

### DIFF
--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1106,6 +1106,25 @@ def test_render_mono_size():
     assert_image_equal_tofile(im, "Tests/images/text_mono.gif")
 
 
+def test_too_many_characters(font):
+    with pytest.raises(ValueError):
+        font.getlength("A" * 1000001)
+    with pytest.raises(ValueError):
+        font.getbbox("A" * 1000001)
+    with pytest.raises(ValueError):
+        font.getmask2("A" * 1000001)
+
+    transposed_font = ImageFont.TransposedFont(font)
+    with pytest.raises(ValueError):
+        transposed_font.getlength("A" * 1000001)
+
+    default_font = ImageFont.load_default()
+    with pytest.raises(ValueError):
+        default_font.getlength("A" * 1000001)
+    with pytest.raises(ValueError):
+        default_font.getbbox("A" * 1000001)
+
+
 @pytest.mark.parametrize(
     "test_file",
     [

--- a/Tests/test_imagefont.py
+++ b/Tests/test_imagefont.py
@@ -1108,21 +1108,21 @@ def test_render_mono_size():
 
 def test_too_many_characters(font):
     with pytest.raises(ValueError):
-        font.getlength("A" * 1000001)
+        font.getlength("A" * 1_000_001)
     with pytest.raises(ValueError):
-        font.getbbox("A" * 1000001)
+        font.getbbox("A" * 1_000_001)
     with pytest.raises(ValueError):
-        font.getmask2("A" * 1000001)
+        font.getmask2("A" * 1_000_001)
 
     transposed_font = ImageFont.TransposedFont(font)
     with pytest.raises(ValueError):
-        transposed_font.getlength("A" * 1000001)
+        transposed_font.getlength("A" * 1_000_001)
 
     default_font = ImageFont.load_default()
     with pytest.raises(ValueError):
-        default_font.getlength("A" * 1000001)
+        default_font.getlength("A" * 1_000_001)
     with pytest.raises(ValueError):
-        default_font.getbbox("A" * 1000001)
+        default_font.getbbox("A" * 1_000_001)
 
 
 @pytest.mark.parametrize(

--- a/docs/reference/ImageFont.rst
+++ b/docs/reference/ImageFont.rst
@@ -18,6 +18,15 @@ OpenType fonts (as well as other font formats supported by the FreeType
 library). For earlier versions, TrueType support is only available as part of
 the imToolkit package.
 
+.. warning::
+    To protect against potential DOS attacks when using arbitrary strings as
+    text input, Pillow will raise a ``ValueError`` if the number of characters
+    is over a certain limit, :py:data:`MAX_STRING_LENGTH`.
+
+    This threshold can be changed by setting
+    :py:data:`MAX_STRING_LENGTH`. It can be disabled by setting
+    ``ImageFont.MAX_STRING_LENGTH = None``.
+
 Example
 -------
 
@@ -73,3 +82,12 @@ Constants
 
     Requires Raqm, you can check support using
     :py:func:`PIL.features.check_feature` with ``feature="raqm"``.
+
+Constants
+---------
+
+.. data:: MAX_STRING_LENGTH
+
+    Set to 1,000,000, to protect against potential DOS attacks. Pillow will
+    raise a ``ValueError`` if the number of characters is over this limit. The
+    check can be disabled by setting ``ImageFont.MAX_STRING_LENGTH = None``.

--- a/docs/releasenotes/9.5.0.1.rst
+++ b/docs/releasenotes/9.5.0.1.rst
@@ -1,0 +1,17 @@
+9.5.0.1
+-------
+
+Security
+========
+
+CVE-2023-44271: Added ImageFont.MAX_STRING_LENGTH
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To protect against potential DOS attacks when using arbitrary strings as text
+input, Pillow will now raise a ``ValueError`` if the number of characters
+passed into ImageFont methods is over a certain limit,
+:py:data:`PIL.ImageFont.MAX_STRING_LENGTH`.
+
+This threshold can be changed by setting
+:py:data:`PIL.ImageFont.MAX_STRING_LENGTH`. It can be disabled by setting
+``ImageFont.MAX_STRING_LENGTH = None``.

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -14,6 +14,7 @@ expected to be backported to earlier versions.
 .. toctree::
   :maxdepth: 2
 
+  9.5.0.1
   9.5.0
   9.4.0
   9.3.0

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -43,7 +43,7 @@ class Layout(IntEnum):
     RAQM = 1
 
 
-MAX_STRING_LENGTH = 1000000
+MAX_STRING_LENGTH = 1_000_000
 
 
 def __getattr__(name):

--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -43,6 +43,9 @@ class Layout(IntEnum):
     RAQM = 1
 
 
+MAX_STRING_LENGTH = 1000000
+
+
 def __getattr__(name):
     for enum, prefix in {Layout: "LAYOUT_"}.items():
         if name.startswith(prefix):
@@ -63,6 +66,12 @@ except ImportError as ex:
 
 
 _UNSPECIFIED = object()
+
+
+def _string_length_check(text):
+    if MAX_STRING_LENGTH is not None and len(text) > MAX_STRING_LENGTH:
+        msg = "too many characters in string"
+        raise ValueError(msg)
 
 
 # FIXME: add support for pilfont2 format (see FontFile.py)
@@ -185,6 +194,7 @@ class ImageFont:
 
         :return: ``(left, top, right, bottom)`` bounding box
         """
+        _string_length_check(text)
         width, height = self.font.getsize(text)
         return 0, 0, width, height
 
@@ -195,6 +205,7 @@ class ImageFont:
 
         .. versionadded:: 9.2.0
         """
+        _string_length_check(text)
         width, height = self.font.getsize(text)
         return width
 
@@ -346,6 +357,7 @@ class FreeTypeFont:
 
         :return: Width for horizontal, height for vertical text.
         """
+        _string_length_check(text)
         return self.font.getlength(text, mode, direction, features, language) / 64
 
     def getbbox(
@@ -405,6 +417,7 @@ class FreeTypeFont:
 
         :return: ``(left, top, right, bottom)`` bounding box
         """
+        _string_length_check(text)
         size, offset = self.font.getsize(
             text, mode, direction, features, language, anchor
         )
@@ -749,6 +762,7 @@ class FreeTypeFont:
                  :py:mod:`PIL.Image.core` interface module, and the text offset, the
                  gap between the starting coordinate and the first marking
         """
+        _string_length_check(text)
         if fill is _UNSPECIFIED:
             fill = Image.core.fill
         else:
@@ -912,6 +926,7 @@ class TransposedFont:
         if self.orientation in (Image.Transpose.ROTATE_90, Image.Transpose.ROTATE_270):
             msg = "text length is undefined for text rotated by 90 or 270 degrees"
             raise ValueError(msg)
+        _string_length_check(text)
         return self.font.getlength(text, *args, **kwargs)
 
 


### PR DESCRIPTION
Backports upstream fix for CVE-2023-44271 (DoS via unbounded text length in ImageFont methods).

## Source
- Upstream PR: https://github.com/python-pillow/Pillow/pull/7244
- Cherry-picked commits:
  - `1fe1bb49c452b0318cad12ea9d97c3bef188e9a7` — Added ImageFont.MAX_STRING_LENGTH
  - `d398fedb9d5af22316c715d2066176d15031d439` — Added underscores for readability

## Changes
- Adds `MAX_STRING_LENGTH = 1_000_000` guard raising `ValueError` in 6 methods: `ImageFont.getbbox`/`.getlength`, `FreeTypeFont.getbbox`/`.getlength`/`.getmask2`, `TransposedFont.getlength`.
- New test `test_too_many_characters` in `Tests/test_imagefont.py`.
- Release notes added to new `docs/releasenotes/9.5.0.1.rst` (upstream's 10.0.0.rst addition was dropped — not applicable to 9.5.x).

## Test plan
- [ ] `pytest Tests/test_imagefont.py`