### PR TITLE
CVE-2023-50447: Restricted env keys for ImageMath.eval()

### DIFF
--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -63,6 +63,11 @@ def test_prevent_exec(expression):
         ImageMath.eval(expression)
 
 
+def test_prevent_double_underscores():
+    with pytest.raises(ValueError):
+        ImageMath.eval("1", {"__": None})
+
+
 def test_logical():
     assert pixel(ImageMath.eval("not A", images)) == 0
     assert pixel(ImageMath.eval("A and B", images)) == "L 2"

--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -68,6 +68,11 @@ def test_prevent_double_underscores():
         ImageMath.eval("1", {"__": None})
 
 
+def test_prevent_builtins():
+    with pytest.raises(ValueError):
+        ImageMath.eval("(lambda: exec('exit()'))()", {"exec": None})
+
+
 def test_logical():
     assert pixel(ImageMath.eval("not A", images)) == 0
     assert pixel(ImageMath.eval("A and B", images)) == "L 2"

--- a/docs/releasenotes/9.5.0.1.rst
+++ b/docs/releasenotes/9.5.0.1.rst
@@ -1,0 +1,12 @@
+9.5.0.1
+-------
+
+Security
+========
+
+CVE-2023-50447: Restricted environment keys for ImageMath.eval()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:py:meth:`~PIL.ImageMath.eval` now raises a ``ValueError`` if the ``expression``
+parameter contains a dictionary key that either contains ``__`` or matches the
+name of one of the Python builtins.

--- a/docs/releasenotes/index.rst
+++ b/docs/releasenotes/index.rst
@@ -14,6 +14,7 @@ expected to be backported to earlier versions.
 .. toctree::
   :maxdepth: 2
 
+  9.5.0.1
   9.5.0
   9.4.0
   9.3.0

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -240,6 +240,10 @@ def eval(expression, _dict={}, **kw):
     args.update(_dict)
     args.update(kw)
     for k, v in list(args.items()):
+        if '__' in k or hasattr(__builtins__, k):
+            msg = f"'{k}' not allowed"
+            raise ValueError(msg)
+
         if hasattr(v, "im"):
             args[k] = _Operand(v)
 

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -238,7 +238,7 @@ def eval(expression, _dict={}, **kw):
     # build execution namespace
     args = ops.copy()
     for k in list(_dict.keys()) + list(kw.keys()):
-        if "__" in k or hasattr(__builtins__, k):
+        if "__" in k or hasattr(builtins, k):
             msg = f"'{k}' not allowed"
             raise ValueError(msg)
 

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -237,13 +237,14 @@ def eval(expression, _dict={}, **kw):
 
     # build execution namespace
     args = ops.copy()
-    args.update(_dict)
-    args.update(kw)
-    for k, v in list(args.items()):
-        if '__' in k or hasattr(__builtins__, k):
+    for k in list(_dict.keys()) + list(kw.keys()):
+        if "__" in k or hasattr(__builtins__, k):
             msg = f"'{k}' not allowed"
             raise ValueError(msg)
 
+    args.update(_dict)
+    args.update(kw)
+    for k, v in args.items():
         if hasattr(v, "im"):
             args[k] = _Operand(v)
 


### PR DESCRIPTION
Backports upstream fix for CVE-2023-50447 (arbitrary code execution via builtins/dunder keys in `ImageMath.eval` env).

## Source
- Upstream PR: https://github.com/python-pillow/Pillow/pull/7655
- Cherry-picked commits:
  - `45c726fd4daa63236a8f3653530f297dc87b160a` — Don't allow `__` or builtins in env dictionaries for ImageMath.eval
  - `0ca3c33c59927e1c7e0c14dbc1eea1dfb2431a80` — Allow ops
  - `557ba59d13de919d04b3fd4cdef8634f7d4b3348` — Include further builtins

## Changes
- `ImageMath.eval` now raises `ValueError` when a user-supplied env key contains `__` or matches a name on the `builtins` module.
- Validation runs only over `_dict` and `kw` keys (not `ops`).
- New tests `test_prevent_double_underscores` and `test_prevent_builtins` in `Tests/test_imagemath.py`.
- Release notes added to new `docs/releasenotes/9.5.0.1.rst` (upstream's 10.2.0.rst update was dropped — not applicable to 9.5.x).

## Test plan
- [ ] `pytest Tests/test_imagemath.py`