### PR TITLE
6.2.2.9 — CVE-2024-28219, CVE-2026-42310, GHSA-4fx9 security backports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,28 @@
 Changelog (Pillow)
 ==================
 
+6.2.2.9 (2026-05-28)
+---------------------
+
+Security
+========
+
+- Fix CVE-2024-28219: Buffer overflow in ``_imagingcms.c`` ``cms_transform_new()``.
+  Two ``strcpy()`` calls copied mode strings into fixed 8-byte buffers without bounds
+  checking. Replaced with ``strncpy()`` and explicit null-termination.
+  [martinPavesio]
+
+- Fix CVE-2026-42310: PDF ``PdfParser`` trailer pointer infinite loop. ``read_prev_trailer()``
+  followed ``Prev`` pointers without cycle detection, allowing a malicious PDF to cause
+  100% CPU usage. Added cycle detection that raises ``PdfFormatError`` on a loop.
+  [martinPavesio]
+
+- Fix GHSA-4fx9-vc88-q2xc: JPEG infinite loop when ``LOAD_TRUNCATED_IMAGES`` is enabled
+  on a truncated file. ``JpegImagePlugin`` now sets ``_ended`` on first synthetic EOF to
+  prevent re-entry.
+  [martinPavesio]
+
+
 6.2.2.8
 -------
 

--- a/docs/releasenotes/6.2.2.9.rst
+++ b/docs/releasenotes/6.2.2.9.rst
@@ -1,0 +1,22 @@
+6.2.2.9
+-------
+
+Security
+========
+
+- :cve:`2024-28219`: Fixed buffer overflow in ``_imagingcms.c``
+  ``cms_transform_new()``. Two ``strcpy()`` calls copied mode strings into
+  fixed 8-byte buffers without bounds checking. Replaced with ``strncpy()``
+  and explicit null-termination.
+  [martinPavesio]
+
+- :cve:`2026-42310`: Fixed PDF ``PdfParser`` trailer pointer infinite loop.
+  ``read_prev_trailer()`` followed ``Prev`` pointers without cycle detection,
+  allowing a malicious PDF to cause 100% CPU usage. Added cycle detection
+  that raises ``PdfFormatError`` on a loop.
+  [martinPavesio]
+
+- Fixed JPEG infinite loop when ``LOAD_TRUNCATED_IMAGES`` is enabled on a
+  truncated file. ``JpegImagePlugin`` now sets ``_ended`` on first synthetic
+  EOF to prevent re-entry. (GHSA-4fx9-vc88-q2xc)
+  [martinPavesio]

--- a/src/PIL/JpegImagePlugin.py
+++ b/src/PIL/JpegImagePlugin.py
@@ -398,9 +398,10 @@ class JpegImageFile(ImageFile.ImageFile):
         """
         s = self.fp.read(read_bytes)
 
-        if not s and ImageFile.LOAD_TRUNCATED_IMAGES:
-            # Premature EOF.
-            # Pretend file is finished adding EOI marker
+        if not s and ImageFile.LOAD_TRUNCATED_IMAGES and not hasattr(self, "_ended"):
+            # Premature EOF. Pretend file is finished adding EOI marker.
+            # _ended prevents re-entry infinite loop (GHSA-4fx9-vc88-q2xc)
+            self._ended = True
             return b"\xFF\xD9"
 
         return s

--- a/src/PIL/PdfParser.py
+++ b/src/PIL/PdfParser.py
@@ -682,7 +682,10 @@ class PdfParser:
         if b"Prev" in self.trailer_dict:
             self.read_prev_trailer(self.trailer_dict[b"Prev"])
 
-    def read_prev_trailer(self, xref_section_offset):
+    def read_prev_trailer(self, xref_section_offset, processed_offsets=None):
+        # Backport of CVE-2026-42310: detect and break trailer pointer cycles
+        if processed_offsets is None:
+            processed_offsets = []
         trailer_offset = self.read_xref_table(xref_section_offset=xref_section_offset)
         m = self.re_trailer_prev.search(
             self.buf[trailer_offset : trailer_offset + 16384]
@@ -695,7 +698,12 @@ class PdfParser:
         )
         trailer_dict = self.interpret_trailer(trailer_data)
         if b"Prev" in trailer_dict:
-            self.read_prev_trailer(trailer_dict[b"Prev"])
+            processed_offsets.append(xref_section_offset)
+            check_format_condition(
+                trailer_dict[b"Prev"] not in processed_offsets,
+                "trailer loop found",
+            )
+            self.read_prev_trailer(trailer_dict[b"Prev"], processed_offsets)
 
     re_whitespace_optional = re.compile(whitespace_optional)
     re_name = re.compile(

--- a/src/PIL/_version.py
+++ b/src/PIL/_version.py
@@ -1,2 +1,2 @@
 # Master version for Pillow
-__version__ = "6.2.2.8"
+__version__ = "6.2.2.9"

--- a/src/PIL/_version.py
+++ b/src/PIL/_version.py
@@ -1,2 +1,2 @@
 # Master version for Pillow
-__version__ = "6.2.2.9"
+__version__ = "6.2.2+security.9"

--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -213,8 +213,10 @@ cms_transform_new(cmsHTRANSFORM transform, char* mode_in, char* mode_out)
 
     self->transform = transform;
 
-    strcpy(self->mode_in, mode_in);
-    strcpy(self->mode_out, mode_out);
+    strncpy(self->mode_in, mode_in, 8);
+    self->mode_in[7] = '\0';
+    strncpy(self->mode_out, mode_out, 8);
+    self->mode_out[7] = '\0';
 
     return (PyObject*) self;
 }


### PR DESCRIPTION
Security backports for Python 2.7. Tags: 6.2.2.8, 6.2.2.9. Ticket: CS-2178.